### PR TITLE
feat: DLL 정보 스크롤 영역 생성 및 동적 갱신 구현

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ add_executable(DLLDetect ${SOURCES} ${MOC_SOURCES} ${UIC_SOURCES} ${resources_ge
 
 target_link_libraries(DLLDetect PRIVATE Qt6::Widgets Qt6::Svg Qt6::Core Qt6::Gui psapi kernel32)
 target_include_directories(DLLDetect PRIVATE include)
+target_link_libraries(DLLDetect PRIVATE Qt6::Widgets Qt6::Core Qt6::Gui)
+
 # target_sources(DLLDetect PRIVATE resources/resources.qrc)
 
 # if(${QT_VERSION} VERSION_LESS 6.1.0)

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -11,6 +11,7 @@
 #include <QTableWidget>
 #include <QPushButton>
 #include <QComboBox>
+#include "ui_mainwindow.h"
 enum class AppStage {
     Home,
     ProcessSelected,
@@ -41,6 +42,10 @@ private:
     QLabel *mainLabel;
     QTableWidget *resultTable;
     std::vector<Result> cachedResults;
+    QTableWidget *processTable;
+    QTableWidget *dllTable;
+    QScrollArea *dllScrollArea;
+    void setupDLLArea();
 
     void handleStageClick(int index);
     void updateStage(AppStage newStage);

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -127,7 +127,7 @@
              <string/>
             </property>
             <property name="pixmap">
-             <pixmap>../../../../Downloads/Apple_logo_black.svg.png</pixmap>
+             <pixmap>../../../Downloads/Apple_logo_black.svg.png</pixmap>
             </property>
             <property name="scaledContents">
              <bool>true</bool>
@@ -153,6 +153,27 @@
       </layout>
      </widget>
     </item>
+
+    <!-- DLL 정보 표시 스크롤 영역 -->
+    <item>
+     <widget class="QScrollArea" name="dllScrollArea">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>500</y>
+        <width>800</width>
+        <height>200</height>
+       </rect>
+      </property>
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="dllContainer">
+       <layout class="QVBoxLayout" name="dllLayout"/>
+      </widget>
+     </widget>
+    </item>
+
    </layout>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>


### PR DESCRIPTION
- DLL 정보 표시를 위한 QScrollArea 추가
  - 프로세스 테이블과 동일한 x 좌표, width, height로 배치
  - 배경색 #12131A로 UI 일관성 유지

- DLL 정보 동적 갱신 기능 구현
  - 프로세스 행 클릭 시, 해당 프로세스의 DLL 정보를 스크롤 영역에 표시

- 예외 처리 및 크래시 방지 코드 추가
  - resultTable이 nullptr인 경우 setupDLLArea() 접근 방지
  - 초기화 순서 조정 및 nullptr 체크 추가