### PR TITLE
ProcessManager Signal/Slot 구조 적용 및 MainWindow 연동 리팩터링

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     src/Result.cpp
     src/ProcessManager.cpp
     src/DLLAnalyzer.cpp
+    include/ProcessManager.h
 
 )
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -12,6 +12,9 @@
 #include <QPushButton>
 #include <QComboBox>
 #include "ui_mainwindow.h"
+
+#include "ProcessManager.h"
+
 enum class AppStage {
     Home,
     ProcessSelected,
@@ -34,6 +37,13 @@ public:
     ~MainWindow();
 
 private:
+    ProcessManager* processManager;
+        std::vector<Result> cachedResults;
+private slots:
+    void onScanResult(const std::vector<Result>& results);
+
+private:
+
     Ui::MainWindow *ui;
     QPushButton *loadButton;
 
@@ -41,7 +51,6 @@ private:
     QVector<QToolButton*> stageButtons;
     QLabel *mainLabel;
     QTableWidget *resultTable;
-    std::vector<Result> cachedResults;
     QTableWidget *processTable;
     QTableWidget *dllTable;
     QScrollArea *dllScrollArea;

--- a/include/ProcessManager.h
+++ b/include/ProcessManager.h
@@ -1,17 +1,21 @@
 #ifndef PROCESSMANAGER_H
 #define PROCESSMANAGER_H
 
+#include <QObject>
 #include <vector>
 #include <QString>
 #include "Result.h"
 
-class ProcessManager
+class ProcessManager : public QObject
 {
+    Q_OBJECT
+
 public:
-    ProcessManager();
+    explicit ProcessManager(QObject* parent = nullptr);
+    void runScan();
 
-
-    std::vector<Result> getProcessList();
+signals:
+    void scanFinished(const std::vector<Result>& results);
 };
 
 #endif


### PR DESCRIPTION
### 변경 내용
- `ProcessManager`에 `runScan()` 함수 및 `scanFinished` 시그널 추가
- 기존 `getProcessList()` 동기 방식에서 비동기 이벤트 기반 구조로 변경
- `MainWindow`에서 `ProcessManager`를 멤버로 선언하고 시그널을 통해 결과 수신
- `loadProcesses()`는 요청만 전송하고, 결과는 `onScanResult()` 슬롯에서 비동기 처리
- UI 갱신 로직을 분리하고, 협업 시 충돌을 줄이기 위한 구조 개선
- `DLLAnalyzer`는 기존처럼 동기 방식 유지하며 구조 변화 없음

### 변경 이유
- `MainWindow.cpp`에 모든 기능이 집중되던 문제를 해결하고, 팀원 간 역할 분리를 명확히 하기 위함
- UI와 로직의 결합도를 낮춰 유지보수와 테스트가 쉬운 구조로 개선
- 향후 비동기 스레드, 진행률 표시, 로깅 등 기능 확장을 용이하게 하기 위한 기반 구조 마련

### 테스트 내용
- 프로세스 목록 로드 및 DLL 수 정상 출력 확인
- 스캔 결과가 UI 테이블에 잘 반영되는지 확인
- 버튼 클릭 → 비동기 요청 → 결과 수신 흐름 정상 작동