### PR TITLE
fix: 충돌 병합 과정에서 잘못 삽입된 onAnalysisFinished 코드 제거

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -417,15 +417,6 @@ void MainWindow::onAnalysisFinished(const QString &resultJson) {
             LogManager::writeLog(lastAnalyzedDllPath, prediction, source, cachedResults);
         }
     }
-
-            QLabel *dllLabel = new QLabel(QString::fromStdString(dll));
-            dllLayout->addWidget(dllLabel);
-        }
-    } else {
-        QLabel *noDLLLabel = new QLabel("DLL 정보가 없습니다.");
-        dllLayout->addWidget(noDLLLabel);
-    }
-
 }
 
 


### PR DESCRIPTION
altools2 브랜치에서 정상 작동하던 onAnalysisFinished 함수에 handleRowClicked 일부 코드가 충돌 처리 중 잘못 병합되어 포함됨. dllLayout, QLabel 관련 코드 제거하고 원래 정상 동작 코드로 복구함.